### PR TITLE
fix to handle Windows-style newlines

### DIFF
--- a/src/text-quoter.js
+++ b/src/text-quoter.js
@@ -20,6 +20,7 @@ var TextQuoter = function(source,opt) {
 	if(source==null) {
 		throw new Error("Missing source argument.");
 	}
+	source = source.replace(/\r\n/g,'\n');
 	if(/[\r\v\f]/.test(source)) {
 		throw new Error("Found an unsupported new line code. The new line code must be '\n'.");
 	}


### PR DESCRIPTION
Added code in the TextQuoter constructor to replace `/\r\n/` with `'\n'` in `source` to avoid errors when loading PEG.js source files that contain Windows-style line endings.

Avoiding this error creating the Tracer:
![image](https://user-images.githubusercontent.com/601467/45163772-18ef3580-b1bf-11e8-9070-e878c8ecccae.png)
